### PR TITLE
feat: Generate initial test cases and backlog from README

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,94 @@
+# Project Backlog: YouTube Uploader CLI
+
+This document tracks potential features, improvements, and bug fixes for the YouTube Uploader CLI.
+
+## ✨ Features
+
+These are new capabilities or significant enhancements to existing functionality.
+
+*   **F001: Web UI for Video Management**
+    *   Description: Develop a Rails-based web user interface for uploading, viewing, and managing video details. (Derived from README "Future: Rails UI")
+    *   Priority: High
+*   **F002: Edit Uploaded Video Details**
+    *   Description: Allow users to modify the title, description, privacy status, tags, and category of a video already uploaded to YouTube via the CLI.
+    *   Priority: Medium
+*   **F003: Delete Uploaded Video**
+    *   Description: Enable users to delete a video from YouTube that was previously uploaded using the CLI.
+    *   Priority: Medium
+*   **F004: List Uploaded Videos**
+    *   Description: Provide a command to list all videos uploaded by the authenticated user via this tool, showing basic info like title, video ID, upload date, and privacy status.
+    *   Priority: Medium
+*   **F005: Support for YouTube Playlists**
+    *   Description: Allow users to add an uploaded video to an existing YouTube playlist or create a new playlist and add the video to it.
+    *   Priority: Low
+*   **F006: Batch Video Uploads**
+    *   Description: Support uploading all videos from a specified directory, potentially with options to apply common metadata or derive metadata from filenames.
+    *   Priority: Medium
+*   **F007: Custom Thumbnail Upload**
+    *   Description: Allow users to specify a custom image file to be used as the thumbnail for the uploaded video.
+    *   Priority: Medium
+*   **F008: Check Video Processing Status**
+    *   Description: After an upload is initiated, provide a way to check the processing status of the video on YouTube (e.g., "processing", "succeeded", "failed").
+    *   Priority: Low
+*   **F009: Database Persistence for Logs - PostgreSQL**
+    *   Description: Implement a gateway to store upload log entries in a PostgreSQL database. (Derived from README "Future: Database Adapters")
+    *   Priority: Medium
+*   **F010: Database Persistence for Logs - MySQL**
+    *   Description: Implement a gateway to store upload log entries in a MySQL database. (Derived from README "Future: Database Adapters")
+    *   Priority: Low
+*   **F011: Scheduled Video Publishing**
+    *   Description: Allow users to specify a future date/time for the video to become public.
+    *   Priority: Low
+*   **F012: Manage Video Comments**
+    *   Description: Basic functionality to list, reply to, or delete comments on videos uploaded via the CLI.
+    *   Priority: Low
+*   **F013: Basic Video Analytics**
+    *   Description: Allow users to fetch and display basic analytics (view count, likes) for their uploaded videos.
+    *   Priority: Low
+
+## ⚙️ Chores
+
+These are tasks to improve the codebase, development process, or maintainability.
+
+*   **C001: Enhanced Error Handling and Reporting**
+    *   Description: Implement more specific error codes and user-friendly messages for CLI outputs. Standardize error responses.
+    *   Priority: High
+*   **C002: Structured Logging**
+    *   Description: Implement structured logging (e.g., JSON format to a dedicated log file) for better audit trails and easier debugging, supplementing the current user-facing log.
+    *   Priority: Medium
+*   **C003: Refactor LogPersistenceGateway for Extensibility**
+    *   Description: Refactor the `LogPersistenceGateway` to more easily accommodate different backend storage solutions (e.g., CSV, PostgreSQL, MySQL).
+    *   Priority: Medium
+*   **C004: Update Dependencies**
+    *   Description: Regularly review and update all gem dependencies (e.g., `google-api-client`, `thor`) to their latest stable and secure versions.
+    *   Priority: Medium
+*   **C005: Increase Test Coverage**
+    *   Description: Write more unit and integration tests, especially for gateway implementations, error conditions, and various CLI options.
+    *   Priority: Medium
+*   **C006: Configuration for Default Upload Options**
+    *   Description: Allow users to set default video upload options (e.g., default privacy status, common tags, default category) via a user-specific configuration file (e.g., `~/.youtube_uploader_cli/config.yml`) or environment variables.
+    *   Priority: Medium
+*   **C007: Add CI/CD Pipeline**
+    *   Description: Set up a Continuous Integration/Continuous Deployment pipeline (e.g., using GitHub Actions) for automated testing, linting, and potentially building releases.
+    *   Priority: Medium
+*   **C008: Interactive Upload Progress**
+    *   Description: For the `upload` command, display a progress bar or more detailed feedback during the video file upload process.
+    *   Priority: Low
+*   **C009: Shell Autocompletion Scripts**
+    *   Description: Generate and provide installation instructions for shell autocompletion scripts (e.g., for Bash, Zsh) to improve CLI usability.
+    *   Priority: Low
+*   **C010: Containerize Application (Docker)**
+    *   Description: Create a Dockerfile and necessary configurations to allow running the CLI application within a Docker container for consistent environments and easier distribution.
+    *   Priority: Low
+*   **C011: Expand README Documentation**
+    *   Description: Add more examples and detailed explanations for each command and feature in the `README.md`.
+    *   Priority: Low
+*   **C012: Automated UI Tests for Web UI**
+    *   Description: If the Rails Web UI (Feature F001) is implemented, add a suite of automated UI tests (e.g., using Capybara/Selenium).
+    *   Priority: Conditional (on F001)
+
+## 🐞 Bugs
+
+This section is for tracking identified bugs. Currently, no bugs are tracked. New bugs will be added here as they are discovered.
+
+*   (No bugs reported yet)

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -1,0 +1,193 @@
+# Test Cases for YouTube Uploader CLI
+
+This document outlines test cases for the YouTube Uploader CLI, derived from the user flow diagram and command specifications.
+
+## 1. Authentication (`youtube_upload auth`)
+
+### TC_AUTH_001: Successful Authentication and Token Storage
+*   **Description:** Verifies that a user can successfully authenticate with Google and the CLI stores the obtained tokens.
+*   **Preconditions:**
+    *   Valid `client_secret.json` is in the `config/` directory.
+    *   User has a valid Google account with YouTube access.
+*   **Steps:**
+    1.  Execute command: `youtube_upload auth`
+    2.  CLI prompts user to open a URL.
+    3.  User opens the URL in a browser.
+    4.  User authenticates with Google and grants the requested permissions.
+    5.  Browser redirects or provides an authorization code that is passed to the CLI.
+    6.  CLI exchanges the code for access and refresh tokens.
+    7.  CLI stores the tokens (e.g., in `config/tokens.yaml`).
+*   **Expected Result:**
+    *   CLI displays a message like "Authentication successful!"
+    *   Token file (e.g., `config/tokens.yaml`) is created/updated with valid tokens.
+
+### TC_AUTH_002: Authentication Failure - User Denies Consent
+*   **Description:** Verifies that authentication fails gracefully if the user denies consent in the Google authentication flow.
+*   **Preconditions:**
+    *   Valid `client_secret.json` is in the `config/` directory.
+*   **Steps:**
+    1.  Execute command: `youtube_upload auth`
+    2.  CLI prompts user to open a URL.
+    3.  User opens the URL in a browser.
+    4.  User authenticates with Google but *denies* consent/permissions.
+*   **Expected Result:**
+    *   CLI displays an authentication failure message (e.g., "Authentication failed: Consent denied by user.").
+    *   No token file is created or modified if it already exists.
+
+### TC_AUTH_003: Authentication Failure - Network Issue During Token Exchange
+*   **Description:** Verifies that authentication fails if the CLI cannot communicate with GoogleAuth to exchange the authorization code for tokens (e.g., due to a network error).
+*   **Preconditions:**
+    *   Valid `client_secret.json` is in the `config/` directory.
+*   **Steps:**
+    1.  Execute command: `youtube_upload auth`
+    2.  CLI prompts user to open a URL.
+    3.  User opens the URL, authenticates, and grants consent.
+    4.  Authorization code is received by the CLI.
+    5.  Simulate a network failure preventing the CLI from reaching Google's token endpoint.
+*   **Expected Result:**
+    *   CLI displays an authentication failure message (e.g., "Authentication failed: Could not connect to Google services to exchange token.").
+    *   No token file is created or modified.
+
+### TC_AUTH_004: Authentication Failure - Invalid Authorization Code
+*   **Description:** Verifies that authentication fails if the CLI attempts to use an invalid, expired, or already used authorization code.
+*   **Preconditions:**
+    *   Valid `client_secret.json` is in the `config/` directory.
+*   **Steps:**
+    1.  Execute command: `youtube_upload auth`
+    2.  CLI prompts user to open a URL.
+    3.  User opens the URL, authenticates, and grants consent.
+    4.  Authorization code is received by the CLI.
+    5.  Manually alter the code to be invalid before the CLI uses it, or attempt to reuse an old code.
+*   **Expected Result:**
+    *   CLI displays an authentication failure message from Google (e.g., "Authentication failed: Invalid grant." or similar error).
+    *   No token file is created or modified.
+
+## 2. Video Upload (`youtube_upload upload`)
+
+### TC_UPLOAD_001: Successful Video Upload - Minimal Options
+*   **Description:** Verifies a successful video upload using only the required file path.
+*   **Preconditions:**
+    *   User is authenticated (valid tokens exist in `config/tokens.yaml`).
+    *   A valid video file (e.g., `test_video.mp4`) exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4`
+*   **Expected Result:**
+    *   CLI displays "Video uploaded successfully: <video_link>".
+    *   The video is uploaded to YouTube with default settings (e.g., private, title matching filename).
+
+### TC_UPLOAD_002: Successful Video Upload - All Valid Options
+*   **Description:** Verifies a successful video upload with all available valid options specified.
+*   **Preconditions:**
+    *   User is authenticated.
+    *   A valid video file (e.g., `test_video.mp4`) exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4 -t "My Awesome Test Video" -d "This is a detailed description of my video." -c "22" -p "public" -g "test,cli,youtube_upload,sample tag"`
+    (Note: "22" is "People & Blogs", ensure this is a valid and available category ID in the test environment)
+*   **Expected Result:**
+    *   CLI displays "Video uploaded successfully: <video_link>".
+    *   The video is uploaded to YouTube with the specified title, description, category, privacy status (public), and tags.
+
+### TC_UPLOAD_003: Successful Video Upload - Unlisted Privacy
+*   **Description:** Verifies a successful video upload with 'unlisted' privacy status.
+*   **Preconditions:**
+    *   User is authenticated.
+    *   A valid video file (e.g., `test_video.mp4`) exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4 -p "unlisted"`
+*   **Expected Result:**
+    *   CLI displays "Video uploaded successfully: <video_link>".
+    *   The video is uploaded to YouTube with 'unlisted' privacy.
+
+### TC_UPLOAD_004: Upload Failure - File Not Found
+*   **Description:** Verifies that the upload fails if the specified video file does not exist.
+*   **Preconditions:**
+    *   User is authenticated.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload non_existent_video.mp4`
+*   **Expected Result:**
+    *   CLI displays an error message (e.g., "Error: Video file not found: non_existent_video.mp4").
+    *   No upload attempt is made to YouTube.
+
+### TC_UPLOAD_005: Upload Failure - Invalid Video File Format (API Rejection)
+*   **Description:** Verifies that the upload fails if the file is not a valid video format recognized by YouTube.
+*   **Preconditions:**
+    *   User is authenticated.
+    *   A non-video file exists (e.g., `document.txt`).
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload document.txt`
+*   **Expected Result:**
+    *   CLI displays an error message from the YouTube API indicating an invalid file type or processing error (e.g., "Upload failed: The file type is not supported." or "Video processing failed.").
+
+### TC_UPLOAD_006: Upload Failure - Invalid Category ID
+*   **Description:** Verifies that the upload fails or defaults if an invalid category ID is provided.
+*   **Preconditions:**
+    *   User is authenticated.
+    *   A valid video file exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4 -c "INVALID_CATEGORY"`
+*   **Expected Result:**
+    *   CLI displays an error message (e.g., "Error: Invalid category ID 'INVALID_CATEGORY'. Please provide a numeric ID.") or the YouTube API rejects it. If the CLI doesn't validate, the API error should be reported.
+
+### TC_UPLOAD_007: Upload Failure - Invalid Privacy Status
+*   **Description:** Verifies that the upload fails if an invalid privacy status string is provided.
+*   **Preconditions:**
+    *   User is authenticated.
+    *   A valid video file exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4 -p "semi-private"`
+*   **Expected Result:**
+    *   CLI displays an error message (e.g., "Error: Invalid privacy status 'semi-private'. Allowed values are: public, private, unlisted.").
+
+### TC_UPLOAD_008: Upload Failure - Not Authenticated
+*   **Description:** Verifies that video upload fails if the user has not authenticated (no tokens).
+*   **Preconditions:**
+    *   No valid authentication tokens are stored (e.g., `config/tokens.yaml` is missing or empty).
+    *   A valid video file exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4`
+*   **Expected Result:**
+    *   CLI displays an error message (e.g., "Error: Authentication required. Please run `youtube_upload auth` first.").
+
+### TC_UPLOAD_009: Upload Failure - Expired/Invalid Tokens
+*   **Description:** Verifies that video upload fails if the stored authentication tokens are expired or invalid.
+*   **Preconditions:**
+    *   Stored authentication tokens in `config/tokens.yaml` are expired or manually corrupted.
+    *   A valid video file exists.
+*   **Steps:**
+    1.  Execute command: `youtube_upload upload test_video.mp4`
+*   **Expected Result:**
+    *   CLI attempts upload, but YouTube API rejects it due to token invalidity.
+    *   CLI displays an error message (e.g., "Error: YouTube API authentication failed. Your tokens might be invalid or expired. Please re-authenticate using `youtube_upload auth`.").
+
+## 3. General CLI Commands
+
+### TC_GEN_001: Display Version
+*   **Description:** Verifies that the CLI can display its version information.
+*   **Steps:**
+    1.  Execute command: `youtube_upload version`
+    2.  Execute command: `youtube_upload --version`
+    3.  Execute command: `youtube_upload -v`
+*   **Expected Result:**
+    *   For each command, the CLI prints its version (e.g., "youtube_upload version 1.0.0").
+
+### TC_GEN_002: Display General Help
+*   **Description:** Verifies that the CLI can display the main help message.
+*   **Steps:**
+    1.  Execute command: `youtube_upload help`
+    2.  Execute command: `youtube_upload -h`
+*   **Expected Result:**
+    *   For each command, the CLI displays a general help message listing available commands, options, and usage instructions.
+
+### TC_GEN_003: Display Command-Specific Help - `auth`
+*   **Description:** Verifies that the CLI can display help for the `auth` command.
+*   **Steps:**
+    1.  Execute command: `youtube_upload help auth`
+*   **Expected Result:**
+    *   CLI displays detailed help information specific to the `auth` command, including its purpose and any options.
+
+### TC_GEN_004: Display Command-Specific Help - `upload`
+*   **Description:** Verifies that the CLI can display help for the `upload` command.
+*   **Steps:**
+    1.  Execute command: `youtube_upload help upload`
+*   **Expected Result:**
+    *   CLI displays detailed help information specific to the `upload` command, including all its parameters (file path, title, description, category, privacy, tags) and their usage.


### PR DESCRIPTION
I've created two new documentation files for you:

- TEST_CASES.md: This contains test cases derived from the user flow detailed in the README. It includes tests for authentication, video uploads (both success and failure scenarios), and CLI helper commands.

- BACKLOG.md: This outlines potential future work, categorized into features, chores, and a placeholder for bugs. It provides a starting point for planning further development of the YouTube Uploader CLI.

These files aim to improve your project structure and guide future development efforts.