### PR TITLE
Fix: Update YouTube API scopes to allow listing videos

### DIFF
--- a/youtube_uploader_cli/app/gateways/cli_youtube_service_gateway.rb
+++ b/youtube_uploader_cli/app/gateways/cli_youtube_service_gateway.rb
@@ -16,7 +16,7 @@ module Gateways
     include YouTubeServiceGateway # Includes the interface methods and default get_authorization_instructions
 
     OOB_URI = 'urn:ietf:wg:oauth:2.0:oob' # Out-of-band URI for desktop apps
-    YOUTUBE_API_SCOPE = Google::Apis::YoutubeV3::AUTH_YOUTUBE_UPLOAD
+    YOUTUBE_API_SCOPE = [Google::Apis::YoutubeV3::AUTH_YOUTUBE_UPLOAD, Google::Apis::YoutubeV3::AUTH_YOUTUBE_READONLY]
 
     def initialize(logger)
       @logger = logger


### PR DESCRIPTION
The `youtube_upload list` command was failing with a `PERMISSION_DENIED` error due to insufficient authentication scopes.

This commit updates the `YOUTUBE_API_SCOPE` in `youtube_uploader_cli/app/gateways/cli_youtube_service_gateway.rb` to include `Google::Apis::YoutubeV3::AUTH_YOUTUBE_READONLY`. This allows the application to request the necessary permissions to list videos.

I confirmed that the `PERMISSION_DENIED` error is resolved, and the application now proceeds further in the authentication/authorization process.