### PR TITLE
Fix: Add 'mine:true' filter to list your videos

### DIFF
--- a/youtube_uploader_cli/app/gateways/cli_youtube_service_gateway.rb
+++ b/youtube_uploader_cli/app/gateways/cli_youtube_service_gateway.rb
@@ -156,7 +156,7 @@ module Gateways
       page_token = options[:page_token]
 
       begin
-        response = @service.list_videos('snippet,player,status', max_results: max_results, page_token: page_token)
+        response = @service.list_videos('snippet,player,status', mine: true, max_results: max_results, page_token: page_token)
 
         return [] if response.items.nil? || response.items.empty?
 


### PR DESCRIPTION
The 'youtube_upload list' command was failing with a 'missingRequiredParameter' error from the YouTube API because no filter (like 'id', 'chart', or 'myRating') was selected.

This commit fixes the issue by adding 'mine: true' to the `videos.list` API call within the `CliYouTubeServiceGateway`. This ensures that the command lists videos uploaded by the authenticated user.

Additionally, a comprehensive test suite has been added for the `CliYouTubeServiceGateway#list_videos` method to:
- Verify that `mine: true` is included in the API call.
- Ensure correct mapping of API responses to `VideoListItem` entities.
- Confirm proper handling of API errors and authentication issues.

Existing tests for the use case and CLI command handler were reviewed and found to not require changes as they operate at a higher level of abstraction.