### PR TITLE
Fix: Correct string interpolation for list command output

### DIFF
--- a/youtube_uploader_cli/app/cli/main.rb
+++ b/youtube_uploader_cli/app/cli/main.rb
@@ -164,7 +164,7 @@ module Cli
         else
           puts "Your Videos:"
           videos.each_with_index do |video, index|
-            puts "\#{index + 1}. \#{video.title} - \#{video.youtube_url} (Published: \#{video.published_at&.strftime('%Y-%m-%d') || 'N/A'})"
+            puts "#{index + 1}. #{video.title} - #{video.youtube_url} (Published: #{video.published_at&.strftime('%Y-%m-%d') || 'N/A'})"
           end
         end
       rescue StandardError => e


### PR DESCRIPTION
The `youtube_upload list` command was displaying the literal interpolation template (e.g., `\#{video.title}`) instead of the actual video details. This was due to unnecessary backslashes escaping the `#{...}` sequences within the output string in `Cli::Main#list`.

This commit removes the erroneous backslashes, enabling correct Ruby string interpolation. The video details will now be displayed as intended.

The existing unit tests for `Cli::Main#list` in `spec/cli/main_spec.rb` were reviewed and confirmed to already expect the correctly interpolated output, so no changes to the tests were required.