### PR TITLE
feat: Display detailed published date in list view

### DIFF
--- a/youtube_uploader_cli/app/cli/main.rb
+++ b/youtube_uploader_cli/app/cli/main.rb
@@ -164,7 +164,7 @@ module Cli
         else
           puts "Your Videos:"
           videos.each_with_index do |video, index|
-            puts "#{index + 1}. #{video.title} - #{video.youtube_url} (Published: #{video.published_at&.strftime('%Y-%m-%d') || 'N/A'})"
+            puts "#{index + 1}. #{video.title} - #{video.youtube_url} (Published: #{video.published_at&.strftime('%Y-%m-%d %H:%M:%S') || 'N/A'})"
           end
         end
       rescue StandardError => e


### PR DESCRIPTION
The `youtube_upload list` command now shows the full timestamp (YYYY-MM-DD HH:MM:SS) for the published date of videos, providing more precise information to you.

The change was made in `youtube_uploader_cli/app/cli/main.rb` by updating the `strftime` format string.